### PR TITLE
Different pagination types

### DIFF
--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -64,6 +64,7 @@ export class AppComponent implements OnInit, OnDestroy {
           this.openConfigSettings();
         }
       });
+    this.configSrv.updateVersions();
   }
 
   search(query: string): void {

--- a/src/app/state/gitlab-config.model.ts
+++ b/src/app/state/gitlab-config.model.ts
@@ -1,12 +1,12 @@
+export interface GitlabVersion {
+  version: string;
+  revision: string;
+}
+
 export interface GitlabConfig {
   id: string;
   gitlabURL: string;
   token: string;
   ignoreSSL: boolean;
+  version: GitlabVersion | null;
 }
-
-// export function createGitlabConfig(params: Partial<GitlabConfig>) {
-//   return {
-
-//   } as GitlabConfig;
-// }

--- a/src/app/state/gitlab-config.service.ts
+++ b/src/app/state/gitlab-config.service.ts
@@ -1,27 +1,67 @@
-import { Injectable } from '@angular/core';
-import { guid } from '@datorama/akita';
+import { Injectable, OnDestroy } from '@angular/core';
+import { applyTransaction, guid } from '@datorama/akita';
+import { forkJoin, of, Subject } from 'rxjs';
+import { catchError, takeUntil } from 'rxjs/operators';
+import { GitlabApiService } from '../gitlab-api.service';
 import { GitlabConfig } from './gitlab-config.model';
+import { GitlabConfigQuery } from './gitlab-config.query';
 import { GitlabConfigStore, ThemeMode } from './gitlab-config.store';
 
 @Injectable({ providedIn: 'root' })
-export class GitlabConfigService {
-  constructor(private gitlabConfigStore: GitlabConfigStore) {}
+export class GitlabConfigService implements OnDestroy {
+  private destroy$ = new Subject<void>();
+
+  constructor(private store: GitlabConfigStore, private query: GitlabConfigQuery, private api: GitlabApiService) {}
+
+  ngOnDestroy(): void {
+    this.destroy$.next();
+    this.destroy$.complete();
+  }
 
   add(gitlabConfig: Omit<GitlabConfig, 'id'>): void {
-    this.gitlabConfigStore.add({ ...gitlabConfig, id: guid() });
+    this.api
+      .getVersion(gitlabConfig)
+      .pipe(takeUntil(this.destroy$))
+      .subscribe(version => {
+        this.store.add({ ...gitlabConfig, id: guid(), version });
+      });
   }
 
   update(id: string, gitlabConfig: Partial<GitlabConfig>): void {
-    this.gitlabConfigStore.update(id, gitlabConfig);
+    this.store.update(id, gitlabConfig);
   }
 
   remove(id: string): void {
-    this.gitlabConfigStore.remove(id);
+    this.store.remove(id);
   }
 
   toggleThemeMode(): void {
-    const currentMode = this.gitlabConfigStore.getValue().ui.themeMode;
+    const currentMode = this.store.getValue().ui.themeMode;
     const newMode: ThemeMode = currentMode === 'light' ? 'dark' : 'light';
-    this.gitlabConfigStore.update(state => ({ ...state, ui: { ...state.ui, themeMode: newMode } }));
+    this.store.update(state => ({ ...state, ui: { ...state.ui, themeMode: newMode } }));
+  }
+
+  updateVersions(): void {
+    const configs = this.query.getAll();
+    forkJoin(
+      configs.map(config =>
+        this.api.getVersion(config).pipe(
+          catchError(err => {
+            console.warn(`Error loading gitlab ${config.gitlabURL} version`, err);
+            return of<null>(null);
+          })
+        )
+      )
+    )
+      .pipe(takeUntil(this.destroy$))
+      .subscribe(versions => {
+        applyTransaction(() => {
+          configs.forEach((config, i) => {
+            if (versions[i] !== null) {
+              this.store.update(config.id, { ...config, version: versions[i] });
+            }
+          });
+        });
+      });
   }
 }


### PR DESCRIPTION
Choose pagination according to gitlab version.

### Problem

 Gitlab prior v13.1 sends `Links` header for keyset pagination instead of `Link`. But `access-control-expose-headers` response header doesn't include `linkS`, only `link`. Because of that `links` value is not available from scripts for old gitlabs and only first page of projects is loading.

### Solution

- load version for every configured gitlab instance on app initialization;
- for versions prior 13.1 use offset pagination, for others use keyset one.